### PR TITLE
Consistent Login.gov and Max.gov capitalization

### DIFF
--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -25,9 +25,9 @@ With Login.gov and MAX.gov, these awards will transform authentication for the f
 - [**Zero Trust Networking (OPM)**](#zero-trust-networking)
 - [**Zero Trust Architecture (ED)**](#zero-trust-architecture)
 - [**Advancing Zero Trust (GSA)**](#advancing-zero-trust)
-- [**Login.Gov (GSA)**](#login-gov)
+- [**Login.gov (GSA)**](#logingov)
 - [**Southwest Border Technology Integration Program (DHS)**](#southwest-border-technology-integration-program)
-- [**MAX.Gov Transition (GSA)**](#max-gov-transition)
+- [**MAX.gov Transition (GSA)**](#max-gov-transition)
 - [**UNISYS Mainframe Migration (HUD)**](#unisys-mainframe-migration)
 - [**Enterprise Cloud Email (DOE)**](#enterprise-cloud-email)
 - [**Farmers.gov Portal (USDA)**](#farmersgov-portal)
@@ -75,7 +75,7 @@ By implementing these modernization efforts, GSA will improve user experience th
  
 ---
 
-## Login Gov
+## Login.gov
 
 {% include project-data.html path="gsa-login-gov" %}
 
@@ -97,7 +97,7 @@ Southwest Border processing involves multiple DHS Components and partner agencie
 
 ---
 
-## MAX Gov Transition
+## MAX.gov Transition
 
 {% include project-data.html path="gsa-max-gov-transition" %}
 


### PR DESCRIPTION
The Login.gov and Max.gov project names have a space instead of a period, and have odd capitalization. For example:

![Screenshot from 2021-09-30 09-26-40](https://user-images.githubusercontent.com/4592/135463831-4ec9d2f1-34b3-4fda-ba42-b61250aab136.png)

This adds the `.` properly into the Login.gov and Max.gov headers on the project page, and lowercases the `g` in the table of contents. This matches how the projects are referred to elsewhere in the document, as well as how Farmers.gov is referenced and capitalized throughout.

This also fixes the autogenerated anchor tags to match the effect (`#login-gov` to `#logingov`).